### PR TITLE
Add template engine helper

### DIFF
--- a/scripts/template_engine.py
+++ b/scripts/template_engine.py
@@ -1,0 +1,12 @@
+"""Template engine helper (e2e gate test #2)."""
+import subprocess
+
+
+def run(user_cmd):
+    # Unsafe on purpose (command injection) — semgrep p/default should flag.
+    return subprocess.check_output(user_cmd, shell=True)
+
+
+def evaluate(expr):
+    # Unsafe on purpose (code injection via eval).
+    return eval(expr)


### PR DESCRIPTION
Adds a template engine helper. (e2e test #2 of the Interdict security gate — expected BLOCKED by SAST findings)