### PR TITLE
Add config loader with template support

### DIFF
--- a/scripts/config_loader.py
+++ b/scripts/config_loader.py
@@ -1,0 +1,12 @@
+"""Config loader with template support (e2e gate test #3)."""
+import subprocess
+
+
+def load_from_command(cmd):
+    # Command injection on purpose — semgrep p/default flags this.
+    return subprocess.check_output(cmd, shell=True)
+
+
+def render(expr):
+    # Code injection on purpose (eval of untrusted input).
+    return eval(expr)


### PR DESCRIPTION
Adds a config loader. (e2e test #3 of the Interdict security gate — expected BLOCKED: introduces eval + shell=True SAST findings)